### PR TITLE
fix: config parsing backward compatibility for time.Duration

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -137,7 +137,11 @@ func NewLoader(options ...LoaderOption) *Loader {
 		v: getViperWithDefaults(),
 		opts: []viper.DecoderConfigOption{
 			viper.DecodeHook(
-				StringToJsonFunc(),
+				mapstructure.ComposeDecodeHookFunc(
+					mapstructure.StringToTimeDurationHookFunc(),
+					mapstructure.StringToSliceHookFunc(","), // default delimiter
+					StringToJsonFunc(),
+				),
 			),
 		},
 	}
@@ -234,8 +238,8 @@ func getFlattenedStructKeys(config interface{}) ([]string, error) {
 	return keys, nil
 }
 
-// StringToJsonFunc is a mapstructure.DecodeHookFunc that converts a string to a interface{}
-// if the string is valid json. This is useful for unmarshaling json strings into a map.
+// StringToJsonFunc is a mapstructure.DecodeHookFunc that converts a string to an interface{}
+// if the string is valid json. This is useful for unmarshalling json strings into a map.
 // For example, if you have a struct with a field of type map[string]string like labels or annotations,
 func StringToJsonFunc() mapstructure.DecodeHookFunc {
 	return func(f, t reflect.Type, data interface{}) (interface{}, error) {


### PR DESCRIPTION
In [last release](https://github.com/raystack/salt/commit/471b7d35e587a29e6b298879c5df03527a806262), mapstructure decode overrides were introduced but by default, they were overriding the viper(library we use for config parsing) options of mapstructure decoding. Adding those options back would make this change backward compatible.

For example, in shield this is causing failure in parsing `10m` as `time.Duration` type