### PR TITLE
feat: add support for custom field names in RQL struct tags

### DIFF
--- a/rql/README.md
+++ b/rql/README.md
@@ -21,7 +21,7 @@ Frontend should send the parameters and operator like this schema to the backend
     },
     { "name": "title", "operator": "like", "value": "xyz" }
   ],
-  "group_by": ["billing_plan_name"],
+  "group_by": ["plan_name"],
   "offset": 20,
   "limit": 50,
   "search": "abcd",
@@ -38,12 +38,12 @@ The validation happens via stuct tags defined on your model. Example:
 
 ```golang
 type Organization struct {
-	Id              int       `rql:"type=number,min=10,max=200"`
-	BillingPlanName string    `rql:"type=string"`
-	CreatedAt       time.Time `rql:"type=datetime"`
-	MemberCount     int       `rql:"type=number"`
-	Title           string    `rql:"type=string"`
-	Enabled         bool      `rql:"type=bool"`
+	Id              int       `rql:"name=id,type=number,min=10,max=200"`
+	BillingPlanName string    `rql:"name=plan_name,type=string"`
+	CreatedAt       time.Time `rql:"name=created_at,type=datetime"`
+	MemberCount     int       `rql:"name=member_count,type=number"`
+	Title           string    `rql:"name=title,type=string"`
+	Enabled         bool      `rql:"name=enabled,type=bool"`
 }
 
 ```
@@ -102,9 +102,9 @@ Using this struct, a SQL query can be generated. Here is an example using `goqu`
 	for _, sort_item := range userInput.Sort {
 		switch sort_item.Order {
 		case "asc":
-			query = query.OrderAppend(goqu.C(sort_item.Key).Asc())
+			query = query.OrderAppend(goqu.C(sort_item.Name).Asc())
 		case "desc":
-			query = query.OrderAppend(goqu.C(sort_item.Key).Desc())
+			query = query.OrderAppend(goqu.C(sort_item.Name).Desc())
 		default:
 		}
 	}

--- a/rql/parser.go
+++ b/rql/parser.go
@@ -142,11 +142,31 @@ func validateStringType(filterItem Filter) error {
 }
 
 func searchKeyInsideStruct(keyName string, val reflect.Value) int {
+	normalizedKey := strings.ToLower(keyName)
+
 	for i := 0; i < val.NumField(); i++ {
-		if strings.ToLower(val.Type().Field(i).Name) == strings.ToLower(keyName) {
+		field := val.Type().Field(i)
+
+		// Check field name
+		if strings.ToLower(field.Name) == normalizedKey {
 			return i
 		}
+
+		// Check rql tag
+		if tag, ok := field.Tag.Lookup("rql"); ok {
+			// Parse the tag string
+			tagParts := strings.Split(tag, ",")
+			for _, part := range tagParts {
+				if strings.HasPrefix(part, "name=") {
+					tagName := strings.TrimPrefix(part, "name=")
+					if strings.ToLower(tagName) == normalizedKey {
+						return i
+					}
+				}
+			}
+		}
 	}
+
 	return -1
 }
 

--- a/rql/parser_test.go
+++ b/rql/parser_test.go
@@ -6,10 +6,10 @@ import (
 )
 
 type TestStruct struct {
-	ID        int32     `rql:"type=number"`
-	Name      string    `rql:"type=string"`
-	IsActive  bool      `rql:"type=bool"`
-	CreatedAt time.Time `rql:"type=datetime"`
+	ID        int32     `rql:"name=id,type=number"`
+	Name      string    `rql:"name=name,type=string"`
+	IsActive  bool      `rql:"name=is_active,type=bool"`
+	CreatedAt time.Time `rql:"name=created_at,type=datetime"`
 }
 
 func TestValidateQuery(t *testing.T) {
@@ -25,8 +25,8 @@ func TestValidateQuery(t *testing.T) {
 				Filters: []Filter{
 					{Name: "ID", Operator: "eq", Value: 123},
 					{Name: "Name", Operator: "like", Value: "test"},
-					{Name: "IsActive", Operator: "eq", Value: true},
-					{Name: "CreatedAt", Operator: "eq", Value: "2021-09-15T15:53:00Z"},
+					{Name: "is_active", Operator: "eq", Value: true},
+					{Name: "created_at", Operator: "eq", Value: "2021-09-15T15:53:00Z"},
 				},
 				Sort: []Sort{
 					{Name: "ID", Order: "asc"},


### PR DESCRIPTION
# Description
This PR enhances the field lookup functionality in the RQL parser to support custom field names via struct tags. Previously, the parser only matched against struct field names. With this change, users can now define custom field names using the `name` parameter in RQL struct tags, enabling more flexible API schemas.

## Changes
- Modified `searchKeyInsideStruct` function to check both struct field names and custom names defined in RQL tags
- Added support for `name=` parameter in RQL struct tags
- Maintained case-insensitive matching for both field names and custom names
- Preserved backward compatibility with existing struct definitions

## Example Usage
```go
// Before
type Organization struct {
    BillingPlanName string    `rql:"type=string"`
}
// Could only be queried using "BillingPlanName"

// After
type Organization struct {
    BillingPlanName string    `rql:"name=plan_name,type=string"`
}
// Can be queried using both "BillingPlanName" and "plan_name"
```

## Benefits
- Allows for more intuitive API field names without changing struct field names
- Enables better separation between internal struct representation and external API schema
- Maintains backward compatibility with existing implementations
- Simplifies API versioning and field renaming

## Testing
- Added unit tests for custom field name lookups
- Verified backward compatibility with existing struct definitions
- Tested case sensitivity handling