### PR TITLE
feat(rql): add function to get data type of field

### DIFF
--- a/rql/parser.go
+++ b/rql/parser.go
@@ -188,6 +188,20 @@ func getDataTypeOfField(tagString string) string {
 	return res
 }
 
+func GetDataTypeOfField(fieldName string, checkStruct interface{}) (string, error) {
+	val := reflect.ValueOf(checkStruct)
+	filterIdx := searchKeyInsideStruct(fieldName, val)
+	if filterIdx < 0 {
+		return "", fmt.Errorf("'%s' is not a valid field", fieldName)
+	}
+	structKeyTag := val.Type().Field(filterIdx).Tag.Get(TAG)
+	dataType := getDataTypeOfField(structKeyTag)
+	if !slices.Contains([]string{DATATYPE_STRING, DATATYPE_BOOL, DATATYPE_NUMBER, DATATYPE_DATETIME}, dataType) {
+		return "", fmt.Errorf("invalid datatype '%s' is for field %s", dataType, fieldName)
+	}
+	return dataType, nil
+}
+
 func isValidOperator(filterItem Filter) bool {
 	switch filterItem.dataType {
 	case DATATYPE_NUMBER:

--- a/rql/parser_test.go
+++ b/rql/parser_test.go
@@ -1,18 +1,19 @@
 package rql
 
 import (
+	"strings"
 	"testing"
 	"time"
 )
 
-type TestStruct struct {
-	ID        int32     `rql:"name=id,type=number"`
-	Name      string    `rql:"name=name,type=string"`
-	IsActive  bool      `rql:"name=is_active,type=bool"`
-	CreatedAt time.Time `rql:"name=created_at,type=datetime"`
-}
-
 func TestValidateQuery(t *testing.T) {
+	type TestStruct struct {
+		ID        int32     `rql:"name=id,type=number"`
+		Name      string    `rql:"name=name,type=string"`
+		IsActive  bool      `rql:"name=is_active,type=bool"`
+		CreatedAt time.Time `rql:"name=created_at,type=datetime"`
+	}
+
 	tests := []struct {
 		name        string
 		query       Query
@@ -82,6 +83,112 @@ func TestValidateQuery(t *testing.T) {
 			err := ValidateQuery(&tt.query, tt.checkStruct)
 			if (err != nil) != tt.expectErr {
 				t.Errorf("ValidateQuery() error = %v, expectErr %v", err, tt.expectErr)
+			}
+		})
+	}
+}
+
+func TestGetDataTypeOfField(t *testing.T) {
+	type TestStruct struct {
+		StringField   string    `rql:"name=string_field,type=string"`
+		NumberField   int       `rql:"name=number_field,type=number"`
+		BoolField     bool      `rql:"name=bool_field,type=bool"`
+		DateTimeField time.Time `rql:"name=datetime_field,type=datetime"`
+		InvalidField  string    `rql:"name=invalid_field,type=invalid"`
+		NoTypeField   string    `rql:"name=no_type_field"` // No type specified
+		NoTagField    string    // No tag at all
+	}
+
+	tests := []struct {
+		name          string
+		fieldName     string
+		expectedType  string
+		expectedError bool
+		errorContains string
+	}{
+		{
+			name:          "String field by struct name",
+			fieldName:     "StringField",
+			expectedType:  "string",
+			expectedError: false,
+		},
+		{
+			name:          "String field by tag name",
+			fieldName:     "string_field",
+			expectedType:  "string",
+			expectedError: false,
+		},
+		{
+			name:          "Number field by struct name",
+			fieldName:     "NumberField",
+			expectedType:  "number",
+			expectedError: false,
+		},
+		{
+			name:          "Number field by tag name",
+			fieldName:     "number_field",
+			expectedType:  "number",
+			expectedError: false,
+		},
+		{
+			name:          "Bool field by struct name",
+			fieldName:     "BoolField",
+			expectedType:  "bool",
+			expectedError: false,
+		},
+		{
+			name:          "DateTime field by struct name",
+			fieldName:     "DateTimeField",
+			expectedType:  "datetime",
+			expectedError: false,
+		},
+		{
+			name:          "Invalid field name",
+			fieldName:     "NonExistentField",
+			expectedType:  "",
+			expectedError: true,
+			errorContains: "is not a valid field",
+		},
+		{
+			name:          "No type specified in tag",
+			fieldName:     "NoTypeField",
+			expectedType:  "string", // Should default to string
+			expectedError: false,
+		},
+		{
+			name:          "No tag field",
+			fieldName:     "NoTagField",
+			expectedType:  "string", // Should default to string
+			expectedError: false,
+		},
+	}
+
+	testStruct := TestStruct{}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dataType, err := GetDataTypeOfField(tt.fieldName, testStruct)
+
+			// Check error cases
+			if tt.expectedError {
+				if err == nil {
+					t.Errorf("Expected error but got none")
+					return
+				}
+				if !strings.Contains(err.Error(), tt.errorContains) {
+					t.Errorf("Expected error containing '%s', got '%s'", tt.errorContains, err.Error())
+				}
+				return
+			}
+
+			// Check success cases
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+				return
+			}
+
+			if dataType != tt.expectedType {
+				t.Errorf("Expected type '%s', got '%s'", tt.expectedType, dataType)
 			}
 		})
 	}


### PR DESCRIPTION
# Description
This PR introduces a new utility function `GetDataTypeOfField` that allows runtime validation and retrieval of field data types from RQL struct tags. This enables better type safety and validation when building queries or processing data.

## New Function
```go
func GetDataTypeOfField(fieldName string, checkStruct interface{}) (string, error)
```

The function:
- Takes a field name and struct instance as input
- Returns the RQL data type ("string", "number", "bool", "datetime") for the field
- Defaults to "string" type if no type is explicitly specified
- Returns error for invalid fields or unsupported data types

## Usage Example
```go
type User struct {
    Name      string    `rql:"name=full_name,type=string"`
    Age       int       `rql:"name=age,type=number"`
    IsActive  bool      `rql:"name=active,type=bool"`
    JoinDate  time.Time `rql:"name=joined_at,type=datetime"`
    Notes     string    `rql:"name=notes"` // defaults to string type
}

user := User{}
dataType, err := GetDataTypeOfField("age", user)
// Returns "number", nil

dataType, err := GetDataTypeOfField("invalid_field", user)
// Returns "", error("'invalid_field' is not a valid field")
```

## Features
- Supports all RQL data types: string, number, bool, datetime
- Works with both struct field names and custom names defined in tags
- Case-insensitive field name matching
- Graceful fallback to string type when no type is specified
- Clear error messages for invalid cases

## Test Coverage
Added comprehensive test suite covering:
- All supported data types
- Custom field name lookups
- Default type handling
- Error scenarios
- Edge cases

## Benefits
- Enables runtime type validation for RQL queries
- Helps prevent type-related errors early in the query building process
- Simplifies implementation of type-aware query builders and validators